### PR TITLE
Adds sub-folder navigation

### DIFF
--- a/SE-GpsFolders/GpsFolderListView.cs
+++ b/SE-GpsFolders/GpsFolderListView.cs
@@ -67,59 +67,96 @@ namespace GpsFolders
         public ListReader<MyGuiControlListbox.Item> GetView(ref string currentFolderView, string searchText, bool expandAllFolders)
         {
             LastSearchText = searchText;
+            
+            bool isSearch = !string.IsNullOrWhiteSpace(searchText);
 
-            if (currentFolderView != null)
+            if (isSearch || (currentFolderView == null && expandAllFolders))
             {
-                if (currentFolderView == "")
+                if (isSearch) currentFolderView = null; // Reset view hierarchy when searching
+                return GetFlatView(searchText);
+            }
+
+            return GetHierarchicalView(currentFolderView, searchText);
+        }
+
+        private ListReader<MyGuiControlListbox.Item> GetHierarchicalView(string currentPath, string searchText)
+        {
+            List<MyGuiControlListbox.Item> items = new List<MyGuiControlListbox.Item>();
+
+            // 1. Add ".." Back Button
+            if (currentPath != null)
+            {
+                string parentPath = GetParentPath(currentPath);
+                items.Add(new GpsFolderRow(parentPath ?? string.Empty, "[ .. ]", Color.Yellow, MyGuiConstants.TEXTURE_ICON_MODS_LOCAL, "Go Up"));
+            }
+
+            // 2. Identify and Add Sub-folders
+            HashSet<string> subFolders = new HashSet<string>();
+            List<MyGps> directItems = new List<MyGps>();
+
+            // Direct items in current folder
+            if (currentPath != null && _folders.TryGetValue(currentPath, out FolderEntry currentFolder))
+            {
+                directItems.AddRange(currentFolder.Entries);
+            }
+            
+            // Scan for subfolders
+            foreach (var kvp in _folders)
+            {
+                string folderPath = kvp.Key;
+                if (currentPath == null)
                 {
-                    return GetFolderView(_unsortedFolder, searchText);
+                    // Root
+                    string segment = folderPath.Split('/')[0];
+                    if (!string.IsNullOrEmpty(segment)) subFolders.Add(segment);
                 }
-                else if (_folders.TryGetValue(currentFolderView, out FolderEntry folder))
+                else if (folderPath.StartsWith(currentPath + "/"))
                 {
-                    return GetFolderView(folder, searchText);
-                }
-                else
-                {
-                    currentFolderView = null;
-                    return GetRootView(searchText, expandAllFolders);
+                    string remainder = folderPath.Substring(currentPath.Length + 1);
+                    string segment = remainder.Split('/')[0];
+                    subFolders.Add(currentPath + "/" + segment); 
                 }
             }
 
-            return GetRootView(searchText, expandAllFolders);
-        }
-
-        private ListReader<MyGuiControlListbox.Item> GetFolderView(FolderEntry folder, string searchText)
-        {
-            bool searchEmpty = String.IsNullOrWhiteSpace(searchText);
-            string[] search = !searchEmpty ? searchText.Split(' ') : Array.Empty<string>();
-
-            List<MyGuiControlListbox.Item> items = new List<MyGuiControlListbox.Item>
+            foreach (var subFolderId in subFolders)
             {
-                new GpsFolderRow(folder.FolderId, '…' + folder.DisplayName, Color.Yellow, MyGuiConstants.TEXTURE_ICON_BLUEPRINTS_LOCAL)
-            };
-
-            foreach (var item in folder.Entries)
-            {
-                if (searchEmpty ^ !Match(item))
+                string displayName = subFolderId.Split('/').Last();
+                int count = 0;
+                foreach(var kv in _folders)
                 {
-                    items.Add(CreateGpsItem(item));
+                    if (kv.Key == subFolderId || kv.Key.StartsWith(subFolderId + "/"))
+                        count += kv.Value.Entries.Count;
                 }
+                string toolTip = $"{count} Item{(count != 1 ? "s" : "")}";
+                items.Add(new GpsFolderRow(subFolderId, displayName, Color.Yellow, MyGuiConstants.TEXTURE_ICON_MODS_LOCAL, toolTip));
+            }
+
+            // 3. Add Direct Items
+            foreach (var gps in directItems)
+            {
+                items.Add(CreateGpsItem(gps));
+            }
+
+            // 4. Unsorted Items (Root only)
+            if (currentPath == null && _unsortedFolder.Entries.Count > 0)
+            {
+                 string toolTip = $"Unsorted Items\n{_unsortedFolder.Entries.Count} Item{(_unsortedFolder.Entries.Count != 1 ? "s" : "")}";
+                 items.Add(new UnsortedGpsFolderRow("", MISC_GPS_SEPARATOR_NAME, Color.Yellow, toolTip));
+                 foreach(var gps in _unsortedFolder.Entries)
+                 {
+                     items.Add(CreateGpsItem(gps));
+                 }
             }
 
             return new ListReader<MyGuiControlListbox.Item>(items);
+        }
 
-            bool Match(MyGps entry)
-            {
-                for (int i = 0; i < search.Length; i++)
-                {
-                    if (entry.Name.Contains(search[i], StringComparison.OrdinalIgnoreCase))
-                    {
-                        return false;
-                    }
-                }
-
-                return true;
-            }
+        private string GetParentPath(string path)
+        {
+            if (string.IsNullOrEmpty(path)) return null;
+            int lastSlash = path.LastIndexOf('/');
+            if (lastSlash == -1) return null; 
+            return path.Substring(0, lastSlash);
         }
 
         private static MyGuiControlListbox.Item CreateGpsItem(MyGps gps)
@@ -132,7 +169,7 @@ namespace GpsFolders
             };
         }
 
-        private ListReader<MyGuiControlListbox.Item> GetRootView(string searchText, bool expandAllFolders)
+        private ListReader<MyGuiControlListbox.Item> GetFlatView(string searchText)
         {
             List<MyGuiControlListbox.Item> items = new List<MyGuiControlListbox.Item>();
 
@@ -145,7 +182,7 @@ namespace GpsFolders
                 int folderIndex = items.Count;
                 foreach (var entry in folder.Value.Entries)
                 {
-                    if ((searchEmpty && expandAllFolders) || (!searchEmpty && Match(folder.Value.FolderId, entry.Name)))
+                    if (searchEmpty || Match(folder.Value.FolderId, entry.Name))
                     {
                         matchAny = true;
                         AddGpsRow(entry);
@@ -164,7 +201,7 @@ namespace GpsFolders
                 int folderIndex = items.Count;
                 foreach (var entry in _unsortedFolder.Entries)
                 {
-                    if ((searchEmpty/* && expandAllFolders*/) || (!searchEmpty && Match(_unsortedFolder.DisplayName, entry.Name)))
+                    if (searchEmpty || Match(_unsortedFolder.DisplayName, entry.Name))
                     {
                         matchAny = true;
                         AddGpsRow(entry);
@@ -173,7 +210,6 @@ namespace GpsFolders
 
                 if ((matchAny || searchEmpty) && folderIndex > 0)
                 {
-                    //AddFolderRow(_unsortedFolder, folderIndex);
                     string toolTip = $"Unsorted Items\n{_unsortedFolder.Entries.Count} Item{(_unsortedFolder.Entries.Count != 1 ? "s" : "")}";
                     items.Insert(folderIndex, new UnsortedGpsFolderRow("", MISC_GPS_SEPARATOR_NAME, Color.Yellow, toolTip));
                 }

--- a/SE-GpsFolders/GpsFolderListView.cs
+++ b/SE-GpsFolders/GpsFolderListView.cs
@@ -70,10 +70,15 @@ namespace GpsFolders
             
             bool isSearch = !string.IsNullOrWhiteSpace(searchText);
 
-            if (isSearch || (currentFolderView == null && expandAllFolders))
+            if (isSearch)
             {
-                if (isSearch) currentFolderView = null; // Reset view hierarchy when searching
-                return GetFlatView(searchText);
+                 currentFolderView = null; // Reset view hierarchy when searching
+                 return GetFlatView(null, searchText);
+            }
+
+            if (expandAllFolders)
+            {
+                return GetFlatView(currentFolderView, searchText);
             }
 
             return GetHierarchicalView(currentFolderView, searchText);
@@ -169,15 +174,28 @@ namespace GpsFolders
             };
         }
 
-        private ListReader<MyGuiControlListbox.Item> GetFlatView(string searchText)
+        private ListReader<MyGuiControlListbox.Item> GetFlatView(string scope, string searchText)
         {
             List<MyGuiControlListbox.Item> items = new List<MyGuiControlListbox.Item>();
+
+            // Add Back Button if in scoped view
+            if (scope != null)
+            {
+                string parentPath = GetParentPath(scope);
+                items.Add(new GpsFolderRow(parentPath ?? string.Empty, "[ .. ]", Color.Yellow, MyGuiConstants.TEXTURE_ICON_MODS_LOCAL, "Go Up"));
+            }
 
             bool searchEmpty = String.IsNullOrWhiteSpace(searchText);
             string[] search = !searchEmpty ? searchText.Split(' ') : Array.Empty<string>();
 
+            // Filter folders based on scope
             foreach (var folder in _folders)
             {
+                // Include if scope is null (Root) OR folder IS scope OR folder starts with scope/
+                bool inScope = scope == null || folder.Key == scope || folder.Key.StartsWith(scope + "/");
+                
+                if (!inScope) continue;
+
                 bool matchAny = false;
                 int folderIndex = items.Count;
                 foreach (var entry in folder.Value.Entries)
@@ -195,7 +213,8 @@ namespace GpsFolders
                 }
             }
 
-            if (_unsortedFolder.Entries.Count > 0)
+            // Unsorted items only shown at Root scope
+            if (scope == null && _unsortedFolder.Entries.Count > 0)
             {
                 bool matchAny = false;
                 int folderIndex = items.Count;
@@ -220,7 +239,9 @@ namespace GpsFolders
             void AddFolderRow(FolderEntry folder, int index)
             {
                 string toolTip = $"{folder.Entries.Count} Item{(folder.Entries.Count != 1 ? "s" : "")}";
-                items.Insert(index, new GpsFolderRow(folder.FolderId, folder.DisplayName, Color.Yellow, MyGuiConstants.TEXTURE_ICON_MODS_LOCAL, toolTip));
+                string displayName = folder.DisplayName;
+                // If scoped, maybe show relative path? Or kept simple. Reverting to full name or keeping simple usage.
+                items.Insert(index, new GpsFolderRow(folder.FolderId, displayName, Color.Yellow, MyGuiConstants.TEXTURE_ICON_MODS_LOCAL, toolTip));
             }
 
             void AddGpsRow(MyGps gps)

--- a/SE-GpsFolders/GpsFolders.csproj
+++ b/SE-GpsFolders/GpsFolders.csproj
@@ -4,79 +4,82 @@
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
+  <PropertyGroup>
+    <GameBinPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\SpaceEngineers\Bin64</GameBinPath>
+  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>x64</PlatformTarget>
-    <OutputPath>..\..\..\..\..\..\Program Files %28x86%29\Steam\steamapps\common\SpaceEngineers\Bin64\Plugins\Local\GpsFolders\</OutputPath>
+    <OutputPath>$(GameBinPath)\Plugins\Local\GpsFolders\</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <StartupObject />
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="0Harmony">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\SpaceEngineers\Bin64\Plugins\Libraries\0Harmony.dll</HintPath>
+      <HintPath>$(GameBinPath)\Plugins\Libraries\0Harmony.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="netstandard" />
     <Reference Include="ProtoBuf.Net">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\SpaceEngineers\Bin64\ProtoBuf.Net.dll</HintPath>
+      <HintPath>$(GameBinPath)\ProtoBuf.Net.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Sandbox.Common">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\SpaceEngineers\Bin64\Sandbox.Common.dll</HintPath>
+      <HintPath>$(GameBinPath)\Sandbox.Common.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Sandbox.Game">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\SpaceEngineers\Bin64\Sandbox.Game.dll</HintPath>
+      <HintPath>$(GameBinPath)\Sandbox.Game.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Sandbox.Graphics">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\SpaceEngineers\Bin64\Sandbox.Graphics.dll</HintPath>
+      <HintPath>$(GameBinPath)\Sandbox.Graphics.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="SpaceEngineers.Game">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\SpaceEngineers\Bin64\SpaceEngineers.Game.dll</HintPath>
+      <HintPath>$(GameBinPath)\SpaceEngineers.Game.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="SpaceEngineers.ObjectBuilders">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\SpaceEngineers\Bin64\SpaceEngineers.ObjectBuilders.dll</HintPath>
+      <HintPath>$(GameBinPath)\SpaceEngineers.ObjectBuilders.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="VRage">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\SpaceEngineers\Bin64\VRage.dll</HintPath>
+      <HintPath>$(GameBinPath)\VRage.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="VRage.Audio">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\SpaceEngineers\Bin64\VRage.Audio.dll</HintPath>
+      <HintPath>$(GameBinPath)\VRage.Audio.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="VRage.Game">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\SpaceEngineers\Bin64\VRage.Game.dll</HintPath>
+      <HintPath>$(GameBinPath)\VRage.Game.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="VRage.Input">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\SpaceEngineers\Bin64\VRage.Input.dll</HintPath>
+      <HintPath>$(GameBinPath)\VRage.Input.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="VRage.Library">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\SpaceEngineers\Bin64\VRage.Library.dll</HintPath>
+      <HintPath>$(GameBinPath)\VRage.Library.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="VRage.Math">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\SpaceEngineers\Bin64\VRage.Math.dll</HintPath>
+      <HintPath>$(GameBinPath)\VRage.Math.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="VRage.Render">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\SpaceEngineers\Bin64\VRage.Render.dll</HintPath>
+      <HintPath>$(GameBinPath)\VRage.Render.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="VRage.Render11">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\SpaceEngineers\Bin64\VRage.Render11.dll</HintPath>
+      <HintPath>$(GameBinPath)\VRage.Render11.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="VRage.Scripting">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\SpaceEngineers\Bin64\VRage.Scripting.dll</HintPath>
+      <HintPath>$(GameBinPath)\VRage.Scripting.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>

--- a/SE-GpsFolders/Helpers.cs
+++ b/SE-GpsFolders/Helpers.cs
@@ -43,7 +43,7 @@ namespace GpsFolders
             MyGuiSandbox.AddScreen(confirmationDialog);
         }
 
-        public static bool TryGetFolderGpses(string folderId, out IEnumerable<MyGps> result)
+        public static bool TryGetFolderGpses(string folderId, out IEnumerable<MyGps> result, bool recursive = false)
         {
             if (!Extensions.IsFolderIdValid(folderId))
             {
@@ -57,24 +57,27 @@ namespace GpsFolders
                 return false;
             }
 
-            result = MySession.Static.Gpss[MySession.Static.LocalPlayerId].Where(i => i.Value.GetFolderId() == folderId).Select(i => i.Value).ToArray();
+            result = MySession.Static.Gpss[MySession.Static.LocalPlayerId]
+                .Where(i => 
+                {
+                    string id = i.Value.GetFolderId();
+                    return id == folderId || (recursive && id != null && id.StartsWith(folderId + "/"));
+                })
+                .Select(i => i.Value).ToArray();
             return result.Count() > 0;
         }
 
-        public static void SetFolderShowOnHud(string folderId, bool showOnHud)
+        public static void SetFolderShowOnHud(string folderId, bool showOnHud, bool recursive = false)
         {
-            if (!TryGetFolderGpses(folderId, out IEnumerable<MyGps> gpses))
+            if (!TryGetFolderGpses(folderId, out IEnumerable<MyGps> gpses, recursive))
             {
                 return;
             }
 
             foreach (MyGps gps in gpses)
             {
-                if (gps.GetFolderId() == folderId)
-                {
-                    gps.ShowOnHud = showOnHud;
-                    MySession.Static.Gpss.SendChangeShowOnHudRequest(MySession.Static.LocalPlayerId, gps.Hash, showOnHud);
-                }
+                gps.ShowOnHud = showOnHud;
+                MySession.Static.Gpss.SendChangeShowOnHudRequest(MySession.Static.LocalPlayerId, gps.Hash, showOnHud);
             }
         }
 

--- a/SE-GpsFolders/Patches_GpsFolders.cs
+++ b/SE-GpsFolders/Patches_GpsFolders.cs
@@ -33,7 +33,37 @@ namespace GpsFolders
         {
             static void Postfix(MyGuiControlTabPage gpsPage)
             {
+                MyGuiControlBase textGpsY = gpsPage.GetControlByName("textGpsY");
+                MyGuiControlBase buttonFromCurrent = gpsPage.GetControlByName("buttonFromCurrent");
+
                 MyGuiControlLabel expandFoldersLabel = new MyGuiControlLabel()
+                {
+                    Position = new Vector2(-0.196f, -0.267f + 0.011f), // Moved slightly up or adjusting layout?
+                };
+
+                MyGuiControlCheckbox includeSubFoldersCheckbox = new MyGuiControlCheckbox
+                {
+                    Position = new Vector2(buttonFromCurrent.Position.X + 0.43f + 0.001f, buttonFromCurrent.Position.Y + 0.049f), // Below "Show All", aligned to the right of the vanilla button.
+                    Name = "IncludeSubFoldersCheckbox",
+                    OriginAlign = MyGuiDrawAlignEnum.HORISONTAL_LEFT_AND_VERTICAL_TOP,
+                    IsChecked = MyTerminalGpsControllerPatches.includeSubFoldersChecked,
+                };
+                includeSubFoldersCheckbox.SetToolTip(new MyToolTips("Include Sub-Folders in Hide/Show operations"));
+                gpsPage.Controls.Add(includeSubFoldersCheckbox);
+
+                MyGuiControlLabel includeSubFoldersLabel = new MyGuiControlLabel
+                {
+                    Position = new Vector2(includeSubFoldersCheckbox.Position.X + includeSubFoldersCheckbox.Size.X + 0.005f, includeSubFoldersCheckbox.Position.Y + includeSubFoldersCheckbox.Size.Y / 2.0f),
+                    Name = "IncludeSubFoldersLabel",
+                    OriginAlign = MyGuiDrawAlignEnum.HORISONTAL_LEFT_AND_VERTICAL_CENTER,
+                    Text = "Include Sub-Folders", 
+                    TextScale = 0.7f,
+                };
+                gpsPage.Controls.Add(includeSubFoldersLabel);
+
+
+                // Existing Expand Folders controls
+                MyGuiControlLabel expandFoldersLabel2 = new MyGuiControlLabel()
                 {
                     Position = new Vector2(-0.196f, -0.267f + 0.011f),
                     Name = "ExpandFoldersLabel",
@@ -41,7 +71,7 @@ namespace GpsFolders
                     Text = MyTexts.GetString("Expand Folders"),
                     TextScale = 0.7f,
                 };
-                gpsPage.Controls.Add(expandFoldersLabel);
+                gpsPage.Controls.Add(expandFoldersLabel2);
 
                 MyGuiControlCheckbox expandFoldersCheckbox = new MyGuiControlCheckbox
                 {
@@ -53,9 +83,9 @@ namespace GpsFolders
                 expandFoldersCheckbox.SetToolTip(new MyToolTips("Expand Folders"));
                 gpsPage.Controls.Add(expandFoldersCheckbox);
 
-                MyGuiControlBase textGpsY = gpsPage.GetControlByName("textGpsY");
-                MyGuiControlBase buttonFromCurrent = gpsPage.GetControlByName("buttonFromCurrent");
-
+                //MyGuiControlBase textGpsY = gpsPage.GetControlByName("textGpsY"); // Moved up
+                //MyGuiControlBase buttonFromCurrent = gpsPage.GetControlByName("buttonFromCurrent"); // Moved up
+ 
                 MyGuiControlButton showFolderOnHudButton = new MyGuiControlButton
                 {
                     Text = "Show All",
@@ -130,8 +160,10 @@ namespace GpsFolders
 
         public static string currentFolderName = null;
         public static bool expandFoldersChecked = false;
+        public static bool includeSubFoldersChecked = false;
 
         static MyGuiControlCheckbox m_expandFoldersCheckbox;
+        static MyGuiControlCheckbox m_includeSubFoldersCheckbox;
         static MyGuiControlButton m_showFolderOnHudButton;
         static MyGuiControlButton m_hideFolderOnHudButton;
         static MyGuiControlTextbox m_gpsFolderNameTextBox;
@@ -157,14 +189,19 @@ namespace GpsFolders
                     Instance.PopulateList();
                 };
 
+                (m_includeSubFoldersCheckbox = (MyGuiControlCheckbox)controlsParent.Controls.GetControlByName("IncludeSubFoldersCheckbox")).IsCheckedChanged += delegate
+                {
+                    includeSubFoldersChecked = !includeSubFoldersChecked;
+                };
+
                 (m_showFolderOnHudButton = (MyGuiControlButton)controlsParent.Controls.GetControlByName("ShowFolderOnHudButton")).ButtonClicked += delegate
                 {
-                    SetSelectedFoldersShowOnHud(true);
+                    SetCurrentViewShowOnHud(true);
                 };
 
                 (m_hideFolderOnHudButton = (MyGuiControlButton)controlsParent.Controls.GetControlByName("HideFolderOnHudButton")).ButtonClicked += delegate
                 {
-                    SetSelectedFoldersShowOnHud(false);
+                    SetCurrentViewShowOnHud(false);
                 };
 
                 (m_gpsFolderNameTextBox = (MyGuiControlTextbox)controlsParent.Controls.GetControlByName("GpsFolderNameTextBox")).TextChanged += textbox =>
@@ -173,17 +210,33 @@ namespace GpsFolders
                 };
                 m_gpsFolderNameTextBox.Enabled = false;
 
-                void SetSelectedFoldersShowOnHud(bool showOnHud)
+                void SetCurrentViewShowOnHud(bool showOnHud)
                 {
-                    foreach (MyGuiControlListbox.Item item in ___m_listboxGps.SelectedItems)
+                    if (currentFolderName != null)
                     {
-                        if (item is GpsFolderRow folder)
+                        // Inside a folder: Apply to current folder (and sub-folders if checked)
+                        Helpers.SetFolderShowOnHud(currentFolderName, showOnHud, includeSubFoldersChecked);
+                    }
+                    else
+                    {
+                        // Root View: Apply to Unsorted AND all Top-Level folders
+                        Helpers.SetUnsortedFolderShowOnHud(showOnHud);
+
+                        // Find all top-level folders
+                        if (MySession.Static != null && MySession.Static.Gpss.ExistsForPlayer(MySession.Static.LocalPlayerId))
                         {
-                            Helpers.SetFolderShowOnHud(folder.Name, showOnHud);
-                        }
-                        else if (item is UnsortedGpsFolderRow separator)
-                        {
-                            Helpers.SetUnsortedFolderShowOnHud(showOnHud);
+                            var playerGps = MySession.Static.Gpss[MySession.Static.LocalPlayerId];
+                            var topFolders = playerGps.Values
+                                .Select(g => g.GetFolderId())
+                                .Where(id => !string.IsNullOrEmpty(id))
+                                .Select(id => id.Split('/')[0])
+                                .Distinct()
+                                .ToList();
+
+                            foreach (var folder in topFolders)
+                            {
+                                Helpers.SetFolderShowOnHud(folder, showOnHud, includeSubFoldersChecked);
+                            }
                         }
                     }
                 }
@@ -379,8 +432,8 @@ namespace GpsFolders
                     ___m_checkGpsShowOnHud.Enabled = true;
                     ___m_checkGpsAlwaysVisible.Enabled = true;
 
-                    m_showFolderOnHudButton?.SetEnabled(false);
-                    m_hideFolderOnHudButton?.SetEnabled(false);
+                    m_showFolderOnHudButton?.SetEnabled(true);
+                    m_hideFolderOnHudButton?.SetEnabled(true);
                     if (m_gpsFolderNameTextBox != null)
                     {
                         if (selectedItem != null && selectedItem.TryGetFolderId(out string tag))
@@ -530,8 +583,8 @@ namespace GpsFolders
             public static void Postfix()
             {
                 Instance = null;
-
                 m_expandFoldersCheckbox = null;
+                m_includeSubFoldersCheckbox = null;
                 m_showFolderOnHudButton = null;
                 m_hideFolderOnHudButton = null;
                 m_gpsFolderNameTextBox = null;

--- a/SE-GpsFolders/Patches_GpsFolders.cs
+++ b/SE-GpsFolders/Patches_GpsFolders.cs
@@ -412,10 +412,10 @@ namespace GpsFolders
                 bool runOriginal = !(senderListbox.SelectedItems.FirstOrDefault() is NonGpsRow);
                 if (senderListbox.SelectedItems.FirstOrDefault() is GpsFolderRow folder)
                 {
-                    if (currentFolderName == null)
-                        currentFolderName = folder.Name;
-                    else
+                    if (string.IsNullOrEmpty(folder.Name))
                         currentFolderName = null;
+                    else
+                        currentFolderName = folder.Name;
 
                     Instance.PopulateList();
                     return false;


### PR DESCRIPTION
Adds sub-folder support. Works with current GPS.

Adds:
- Sub folders support. Separated with `/` i.e. `some/sub/folder`
- Sub folders navigation - The ability to navigate the folder tree.
- Show / Hide buttons operate on current scope with the option to include sub-folders in the operation.
- Expand Folders toggle operates on current scope. Can select folders to scope into

# Photos
Root
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/52207e57-c12d-4d8b-b8d9-c4630b0072ef" />

`test` dir
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/1e77c641-23ba-46ae-8d48-c0dd179388c8" />

`test/1` dir
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/7f106c13-6678-4142-8066-f002c9be88e9" />

Root Expand Folders selected (Added `test 2/1`)
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/fecd0928-1442-4048-8932-58fd085ee1bf" />

`test` Expanded Folders selected
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/558d3352-1149-4499-a328-4e284a780beb" />

`test 2` Expanded Folders selected
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/1e309ec9-da71-42cb-a8b3-40f94c446264" />
